### PR TITLE
Add ELF file loading support

### DIFF
--- a/loadp2_src/build_cygwin
+++ b/loadp2_src/build_cygwin
@@ -1,1 +1,1 @@
-gcc -Wall loadp2.c osint_cygwin.c -o loadp2
+gcc -Wall loadp2.c loadelf.c osint_cygwin.c -o loadp2

--- a/loadp2_src/build_linux
+++ b/loadp2_src/build_linux
@@ -1,1 +1,1 @@
-gcc -Wall loadp2.c osint_linux.c -o loadp2
+gcc -Wall loadp2.c loadelf.c osint_linux.c -o loadp2

--- a/loadp2_src/build_macos
+++ b/loadp2_src/build_macos
@@ -1,1 +1,1 @@
-gcc -Wall -DMACOSX loadp2.c osint_linux.c -o loadp2
+gcc -Wall -DMACOSX loadp2.c loadelf.c osint_linux.c -o loadp2

--- a/loadp2_src/build_mingw
+++ b/loadp2_src/build_mingw
@@ -1,1 +1,1 @@
-gcc -Wall loadp2.c osint_mingw.c -o loadp2
+gcc -Wall loadp2.c loadelf.c osint_mingw.c -o loadp2

--- a/loadp2_src/loadelf.c
+++ b/loadp2_src/loadelf.c
@@ -1,0 +1,366 @@
+/* loadelf.c - an elf loader for the Parallax Propeller microcontroller
+
+Copyright (c) 2011 David Michael Betz
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+and associated documentation files (the "Software"), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute,
+sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or
+substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+#include "loadelf.h"
+
+#define message printf
+
+#ifndef TRUE
+#define TRUE    1
+#define FALSE   0
+#endif
+
+#define IDENT_SIGNIFICANT_BYTES 9
+
+static uint8_t ident[] = {
+    0x7f, 'E', 'L', 'F',                        // magic number
+    0x01,                                       // class
+    0x01,                                       // data
+    0x01,                                       // version
+    0x00,                                       // os / abi identification
+    0x00,                                       // abi version
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00    // padding
+};
+
+static int FindProgramTableEntry(ElfContext *c, ElfSectionHdr *section, ElfProgramHdr *program);
+static void ShowSectionHdr(ElfSectionHdr *section);
+static void ShowProgramHdr(ElfProgramHdr *program);
+
+int ReadAndCheckElfHdr(FILE *fp, ElfHdr *hdr)
+{
+    if (fread(hdr, 1, sizeof(ElfHdr), fp) != sizeof(ElfHdr))
+        return FALSE;
+    return memcmp(ident, hdr->ident, IDENT_SIGNIFICANT_BYTES) == 0;
+}
+
+ElfContext *OpenElfFile(FILE *fp, ElfHdr *hdr)
+{
+    ElfSectionHdr section;
+    ElfContext *c;
+    
+    /* allocate and initialize a context structure */
+    if (!(c = (ElfContext *)malloc(sizeof(ElfContext))))
+        return NULL;
+    memset(c, 0, sizeof(ElfContext));
+    c->hdr = *hdr;
+    c->fp = fp;
+        
+    /* get the string section offset */
+    if (!LoadSectionTableEntry(c, c->hdr.shstrndx, &section)) {
+        free(c);
+        return NULL;
+    }
+    c->stringOff = section.offset;
+    
+    /* get the symbol table section offset */
+    if (FindSectionTableEntry(c, ".symtab", &section)) {
+        c->symbolOff = section.offset;
+        c->symbolCnt = section.size / sizeof(ElfSymbol);
+        if (FindSectionTableEntry(c, ".strtab", &section))
+            c->symbolStringOff = section.offset;
+        else {
+            c->symbolOff = 0;
+            c->symbolCnt = 0;
+        }
+    }
+    
+    /* return the context */
+    return c;
+}
+
+void FreeElfContext(ElfContext *c)
+{
+    free(c);
+}
+
+void CloseElfFile(ElfContext *c)
+{
+    if (c->fp) {
+        fclose(c->fp);
+        c->fp = 0;
+    }
+}
+
+int GetProgramSize(ElfContext *c, uint32_t *pStart, uint32_t *pSize, uint32_t *pCogImagesSize)
+{
+    ElfProgramHdr program;
+    uint32_t start = 0xffffffff;
+    uint32_t end = 0;
+    uint32_t cogImagesStart = 0xffffffff;
+    uint32_t cogImagesEnd = 0;
+    int cogImagesFound = FALSE;
+    int i;
+    for (i = 0; i < c->hdr.phnum; ++i) {
+        if (!LoadProgramTableEntry(c, i, &program)) {
+            message("Can't read ELF program header %d", i);
+            return FALSE;
+        }
+        if (program.paddr < COG_DRIVER_IMAGE_BASE) {
+            if (program.paddr < start)
+                start = program.paddr;
+            if (program.paddr + program.filesz > end)
+                end = program.paddr + program.filesz;
+        }
+        else {
+            if (program.paddr < cogImagesStart)
+                cogImagesStart = program.paddr;
+            if (program.paddr + program.filesz > cogImagesEnd)
+                cogImagesEnd = program.paddr + program.filesz;
+            cogImagesFound = TRUE;
+        }
+    }
+    *pStart = start;
+    *pSize = end - start;
+    *pCogImagesSize = cogImagesFound ? cogImagesEnd - cogImagesStart : 0;
+    return TRUE;
+}
+
+int FindProgramSegment(ElfContext *c, const char *name, ElfProgramHdr *program)
+{
+    ElfSectionHdr section;
+    if (!FindSectionTableEntry(c, name, &section))
+        return -1;
+    return FindProgramTableEntry(c, &section, program);
+}
+
+uint8_t *LoadProgramSegment(ElfContext *c, ElfProgramHdr *program)
+{
+    uint8_t *buf;
+    if (!(buf = (uint8_t *)malloc(program->filesz)))
+        return NULL;
+    if (fseek(c->fp, program->offset, SEEK_SET) != 0) {
+        free(buf);
+        return NULL;
+    }
+    if (fread(buf, 1, program->filesz, c->fp) != program->filesz) {
+        free(buf);
+        return NULL;
+    }
+    return buf;
+}
+
+int FindSectionTableEntry(ElfContext *c, const char *name, ElfSectionHdr *section)
+{
+    int i;
+    for (i = 0; i < c->hdr.shnum; ++i) {
+        char thisName[ELFNAMEMAX], *p = thisName;
+        int cnt, ch;
+        if (!LoadSectionTableEntry(c, i, section)) {
+            message("Can't read ELF section header %d", i);
+            return 1;
+        }
+        fseek(c->fp, c->stringOff + section->name, SEEK_SET);
+        for (cnt = 0; ++cnt < ELFNAMEMAX && (ch = getc(c->fp)) != '\0'; )
+            *p++ = ch;
+        *p = '\0';
+        if (strcmp(name, thisName) == 0)
+            return TRUE;
+    }
+    return FALSE;
+}
+
+int LoadSectionTableEntry(ElfContext *c, int i, ElfSectionHdr *section)
+{
+    return fseek(c->fp, c->hdr.shoff + i * c->hdr.shentsize, SEEK_SET) == 0
+        && fread(section, 1, sizeof(ElfSectionHdr), c->fp) == sizeof(ElfSectionHdr);
+}
+
+static int FindProgramTableEntry(ElfContext *c, ElfSectionHdr *section, ElfProgramHdr *program)
+{
+    int i;
+    for (i = 0; i < c->hdr.shnum; ++i) {
+        if (!LoadProgramTableEntry(c, i, program)) {
+            message("Can't read ELF program header %d", i);
+            return -1;
+        }
+        if (SectionInProgramSegment(section, program))
+            return i;
+    }
+    return -1;
+}
+
+int LoadProgramTableEntry(ElfContext *c, int i, ElfProgramHdr *program)
+{
+    return fseek(c->fp, c->hdr.phoff + i * c->hdr.phentsize, SEEK_SET) == 0
+        && fread(program, 1, sizeof(ElfProgramHdr), c->fp) == sizeof(ElfProgramHdr);
+}
+
+int FindElfSymbol(ElfContext *c, const char *name, ElfSymbol *symbol)
+{
+    int i;
+    for (i = 1; i < c->symbolCnt; ++i) {
+        char thisName[ELFNAMEMAX];
+        if (LoadElfSymbol(c, i, thisName, symbol) == 0 && strcmp(name, thisName) == 0)
+            return TRUE;
+    }
+    return FALSE;
+}
+
+int LoadElfSymbol(ElfContext *c, int i, char *name, ElfSymbol *symbol)
+{
+    char *p = name;
+    if (fseek(c->fp, c->symbolOff + i * sizeof(ElfSymbol), SEEK_SET) != 0
+    ||  fread(symbol, 1, sizeof(ElfSymbol), c->fp) != sizeof(ElfSymbol))
+        return -1;
+    if (symbol->name) {
+        int cnt, ch;
+        fseek(c->fp, c->symbolStringOff + symbol->name, SEEK_SET);
+        for (cnt = 0; ++cnt < ELFNAMEMAX && (ch = getc(c->fp)) != '\0'; )
+            *p++ = ch;
+    }
+    *p = '\0';
+    return 0;
+}
+
+void ShowElfFile(ElfContext *c)
+{
+    ElfSectionHdr section;
+    ElfProgramHdr program;
+    int i;
+
+    /* show file header */
+    printf("ELF Header:\n");
+    printf("  ident:    ");
+    for (i = 0; i < sizeof(c->hdr.ident); ++i)
+        printf(" %02x", c->hdr.ident[i]);
+    putchar('\n');
+    printf("  type:      %04x\n", c->hdr.type);
+    printf("  machine:   %04x\n", c->hdr.machine);
+    printf("  version:   %08x\n", c->hdr.version);
+    printf("  entry:     %08x\n", c->hdr.entry);
+    printf("  phoff:     %08x\n", c->hdr.phoff);
+    printf("  shoff:     %08x\n", c->hdr.shoff);
+    printf("  flags:     %08x\n", c->hdr.flags);
+    printf("  ehsize:    %d\n", c->hdr.entry);
+    printf("  phentsize: %d\n", c->hdr.phentsize);
+    printf("  phnum:     %d\n", c->hdr.phnum);
+    printf("  shentsize: %d\n", c->hdr.shentsize);
+    printf("  shnum:     %d\n", c->hdr.shnum);
+    printf("  shstrndx:  %d\n", c->hdr.shstrndx);
+    
+    /* show the section table */
+    for (i = 0; i < c->hdr.shnum; ++i) {
+        char name[ELFNAMEMAX], *p = name;
+        int cnt, ch;
+        if (!LoadSectionTableEntry(c, i, &section)) {
+            printf("error: can't read section header %d\n", i);
+            return;
+        }
+        fseek(c->fp, c->stringOff + section.name, SEEK_SET);
+        for (cnt = 0; ++cnt < ELFNAMEMAX && (ch = getc(c->fp)) != '\0'; )
+            *p++ = ch;
+        *p = '\0';
+        printf("SectionHdr %d:\n", i);
+        printf("  name:      %08x %s\n", section.name, name);
+        ShowSectionHdr(&section);
+    }
+        
+    /* show the program table */
+    for (i = 0; i < c->hdr.phnum; ++i) {
+        if (!LoadProgramTableEntry(c, i, &program)) {
+            printf("error: can't read program header %d\n", i);
+            return;
+        }
+        printf("ProgramHdr %d:\n", i);
+        ShowProgramHdr(&program);
+    }
+    
+    /* show the symbol table */
+    for (i = 1; i < c->symbolCnt; ++i) {
+        char name[ELFNAMEMAX];
+        ElfSymbol symbol;
+        if (LoadElfSymbol(c, i, name, &symbol) == 0 && symbol.name && INFO_BIND(symbol.info) == STB_GLOBAL)
+            printf("  %08x %s: %08x\n", symbol.name, name, symbol.value);
+    }
+}
+
+static void ShowSectionHdr(ElfSectionHdr *section)
+{
+    printf("  type:      %08x\n", section->type);
+    printf("  flags:     %08x\n", section->flags);
+    printf("  addr:      %08x\n", section->addr);
+    printf("  offset:    %08x\n", section->offset);
+    printf("  size:      %08x\n", section->size);
+    printf("  link:      %08x\n", section->link);
+    printf("  info:      %08x\n", section->info);
+    printf("  addralign: %08x\n", section->addralign);
+    printf("  entsize:   %08x\n", section->entsize);
+}
+
+static void ShowProgramHdr(ElfProgramHdr *program)
+{
+    printf("  type:      %08x\n", program->type);
+    printf("  offset:    %08x\n", program->offset);
+    printf("  vaddr:     %08x\n", program->vaddr);
+    printf("  paddr:     %08x\n", program->paddr);
+    printf("  filesz:    %08x\n", program->filesz);
+    printf("  memsz:     %08x\n", program->memsz);
+    printf("  flags:     %08x\n", program->flags);
+    printf("  align:     %08x\n", program->align);
+}
+
+#ifdef MAIN
+
+int main(int argc, char *argv[])
+{
+    ElfContext *c;
+    ElfHdr hdr;
+    FILE *fp;
+
+    /* check the arguments */
+    if (argc != 2) {
+        printf("usage: loadelf <file>\n");
+        return 1;
+    }
+    
+    /* open the image file */
+    if (!(fp = fopen(argv[1], "rb"))) {
+        printf("error: opening '%s'\n", argv[1]);
+        return 1;
+    }
+    
+    /* make sure it's an elf file */
+    if (!ReadAndCheckElfHdr(fp, &hdr)) {
+        printf("error: not an elf file");
+        return 1;
+    }
+    
+    /* open the elf file */
+    if (!(c = OpenElfFile(fp, &hdr))) {
+        printf("error: opening elf file\n");
+        return 1;
+    }
+    
+    /* show the contents of the elf file */
+    ShowElfFile(c);
+    
+    /* close the elf file */
+    CloseElfFile(c);
+    
+    return 0;
+}
+
+#endif
+

--- a/loadp2_src/loadelf.h
+++ b/loadp2_src/loadelf.h
@@ -1,0 +1,143 @@
+/* loadelf.h - an elf loader for the Parallax Propeller microcontroller
+
+Copyright (c) 2011 David Michael Betz
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+and associated documentation files (the "Software"), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute,
+sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or
+substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+*/
+
+#ifndef __LOADELF_H__
+#define __LOADELF_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+
+/* base address of cog driver overlays to be loaded into eeprom */
+#define COG_DRIVER_IMAGE_BASE   0xc0000000
+
+#define ST_NULL     0
+#define ST_PROGBITS 1
+#define ST_SYMTAB   2
+#define ST_STRTAB   3
+#define ST_RELA     4
+#define ST_HASH     5
+#define ST_DYNAMIC  6
+#define ST_NOTE     7
+#define ST_NOBITS   8
+#define ST_REL      9
+#define ST_SHLIB    10
+#define ST_DYNSYM   11
+
+#define SF_WRITE    1
+#define SF_ALLOC    2
+#define SF_EXECUTE  4
+
+#define ELFNAMEMAX  128
+
+typedef struct {
+    uint8_t     ident[16];
+    uint16_t    type;
+    uint16_t    machine;
+    uint32_t    version;
+    uint32_t    entry;
+    uint32_t    phoff;
+    uint32_t    shoff;
+    uint32_t    flags;
+    uint16_t    ehsize;
+    uint16_t    phentsize;
+    uint16_t    phnum;
+    uint16_t    shentsize;
+    uint16_t    shnum;
+    uint16_t    shstrndx;
+} ElfHdr;
+
+typedef struct {
+    uint32_t    name;
+    uint32_t    type;
+    uint32_t    flags;
+    uint32_t    addr;
+    uint32_t    offset;
+    uint32_t    size;
+    uint32_t    link;
+    uint32_t    info;
+    uint32_t    addralign;
+    uint32_t    entsize;
+} ElfSectionHdr;
+
+typedef struct {
+    uint32_t    type;
+    uint32_t    offset;
+    uint32_t    vaddr;
+    uint32_t    paddr;
+    uint32_t    filesz;
+    uint32_t    memsz;
+    uint32_t    flags;
+    uint32_t    align;
+} ElfProgramHdr;
+
+typedef struct {
+    uint32_t    name;
+    uint32_t    value;
+    uint32_t    size;
+    uint8_t     info;
+    uint8_t     other;
+    uint16_t    shndx;
+} ElfSymbol;
+
+#define INFO_BIND(i)    ((i) >> 4)
+#define INFO_TYPE(i)    ((i) & 0x0f)
+
+#define STB_LOCAL   0
+#define STB_GLOBAL  1
+#define STB_WEAK    2
+
+typedef struct {
+    ElfHdr hdr;
+    uint32_t stringOff;
+    uint32_t symbolOff;
+    uint32_t symbolStringOff;
+    uint32_t symbolCnt;
+    FILE *fp;
+} ElfContext;
+
+#define SectionInProgramSegment(s, p) \
+        ((s)->offset >= (p)->offset && (s)->offset < (p)->offset + (p)->filesz \
+     &&  (s)->addr   >= (p)->vaddr  && (s)->addr   < (p)->vaddr  + (p)->memsz)
+
+#define ProgramSegmentsMatch(p1, p2) \
+        ((p1)->offset == (p2)->offset && (p1)->vaddr == (p2)->vaddr)
+
+int ReadAndCheckElfHdr(FILE *fp, ElfHdr *hdr);
+ElfContext *OpenElfFile(FILE *fp, ElfHdr *hdr);
+void FreeElfContext(ElfContext *c);
+int GetProgramSize(ElfContext *c, uint32_t *pStart, uint32_t *pSize, uint32_t *pCogImagesSize);
+int FindSectionTableEntry(ElfContext *c, const char *name, ElfSectionHdr *section);
+int FindProgramSegment(ElfContext *c, const char *name, ElfProgramHdr *program);
+uint8_t *LoadProgramSegment(ElfContext *c, ElfProgramHdr *program);
+int LoadSectionTableEntry(ElfContext *c, int i, ElfSectionHdr *section);
+int LoadProgramTableEntry(ElfContext *c, int i, ElfProgramHdr *program);
+int FindElfSymbol(ElfContext *c, const char *name, ElfSymbol *symbol);
+int LoadElfSymbol(ElfContext *c, int i, char *name, ElfSymbol *symbol);
+void ShowElfFile(ElfContext *c);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/loadp2_src/loadelf.h
+++ b/loadp2_src/loadelf.h
@@ -48,6 +48,9 @@ extern "C" {
 #define SF_ALLOC    2
 #define SF_EXECUTE  4
 
+#define PT_NULL     0    
+#define PT_LOAD     1
+    
 #define ELFNAMEMAX  128
 
 typedef struct {

--- a/loadp2_src/loadp2.c
+++ b/loadp2_src/loadp2.c
@@ -158,7 +158,7 @@ loadElfFile(FILE *infile, ElfHdr *hdr)
             printf("Error reading ELF program header %d\n", i);
             return -1;
         }
-        if (program.type != 1) {
+        if (program.type != PT_LOAD) {
             continue;
         }
         printf("load %d bytes at %x\n", program.filesz, program.paddr);
@@ -189,7 +189,7 @@ loadElfFile(FILE *infile, ElfHdr *hdr)
             printf("Error reading ELF program header %d\n", i);
             return -1;
         }
-        if (program.type != 1) {
+        if (program.type != PT_LOAD) {
             continue;
         }
         fseek(infile, program.offset, SEEK_SET);

--- a/loadp2_src/loadp2.c
+++ b/loadp2_src/loadp2.c
@@ -29,6 +29,7 @@
 #include <string.h>
 #include <stdint.h>
 #include "osint.h"
+#include "loadelf.h"
 
 #define LOAD_CHIP   0
 #define LOAD_FPGA   1
@@ -86,7 +87,7 @@ promptexit(int r)
 static void Usage(void)
 {
 printf("\
-loadp2 - a loader for the propeller 2 - version 0.013, 2019-02-06\n\
+loadp2 - a loader for the propeller 2 - version 0.013 + ELF, 2019-07-21\n\
 usage: loadp2\n\
          [ -p port ]               serial port\n\
          [ -b baud ]               user baud rate (default is %d)\n\
@@ -124,29 +125,158 @@ int compute_checksum(int *ptr, int num)
     return checksum;
 }
 
-int loadfilesingle(char *fname)
+/*
+ * ultimately the final image to be loaded ends up in a binary blob pointed to
+ * by g_filedata, of size g_filesize. g_fileptr is used to stream the data
+ */
+
+uint8_t *g_filedata;
+int g_filesize;
+int g_fileptr;
+
+/*
+ * read an ELF file into memory
+ */
+int
+loadElfFile(FILE *infile, ElfHdr *hdr)
 {
-    FILE *infile;
-    int num, size, i;
-    int patch = patch_mode;
-    int totnum = 0;
-    int checksum = 0;
+    ElfContext *c;
+    ElfProgramHdr program;
+    int size = 0;
+    unsigned int base = -1;
+    unsigned int top = 0;
+    int i, r;
     
+    c = OpenElfFile(infile, hdr);
+    if (!c) {
+        printf("error: opening elf file\n");
+        return -1;
+    }
+    /* walk through the program table */
+    for (i = 0; i < c->hdr.phnum; i++) {
+        if (!LoadProgramTableEntry(c, i, &program)) {
+            printf("Error reading ELF program header %d\n", i);
+            return -1;
+        }
+        if (program.type != 1) {
+            continue;
+        }
+        printf("load %d bytes at %x\n", program.filesz, program.paddr);
+        if (program.paddr < base) {
+            base = program.paddr;
+        }
+        if (program.memsz < program.filesz) {
+            printf("bad ELF file: program size in file too big\n");
+            return -1;
+        }
+        if (program.paddr + program.memsz > top) {
+            top = program.paddr + program.memsz;
+        }
+    }
+    size = top - size;
+    if (size > 0xffffff) {
+        printf("image size %d bytes is too large to handle\n", size);
+        return -1;
+    }
+    g_filedata = (uint8_t *)calloc(1, size);
+    if (!g_filedata) {
+        printf("Could not allocate %d bytes\n", size);
+        return -1;
+    }
+    g_filesize = size;
+    for (i = 0; i < c->hdr.phnum; i++) {
+        if (!LoadProgramTableEntry(c, i, &program)) {
+            printf("Error reading ELF program header %d\n", i);
+            return -1;
+        }
+        if (program.type != 1) {
+            continue;
+        }
+        fseek(infile, program.offset, SEEK_SET);
+        r = fread(g_filedata + program.paddr - base, 1, program.filesz, infile);
+        if (r != program.filesz) {
+            printf("read error in ELF file\n");
+            return -1;
+        }
+    }
+    printf("ELF: total size = %d\n", size);
+    return size;
+}
+
+/*
+ * read a simple binary file into memory
+ * sets g_filedata to point to the data, 
+ * and g_filesize to the length
+ * returns g_filesize, or -1 on error
+ */
+
+int 
+loadBinaryFile(char *fname)
+{
+    int size;
+    FILE *infile;
+    ElfHdr hdr;
+    
+    g_fileptr = 0;
     infile = fopen(fname, "rb");
     if (!infile)
     {
         printf("Could not open %s\n", fname);
-        return 1;
+        return -1;
     }
+    if (ReadAndCheckElfHdr(infile, &hdr)) {
+        /* this is an ELF file, load using LoadElf instead */
+        return loadElfFile(infile, &hdr);
+    } else {
+        printf("not an ELF file\n");
+    }
+    
     fseek(infile, 0, SEEK_END);
     size = ftell(infile);
     fseek(infile, 0, SEEK_SET);
+    g_filedata = (uint8_t *)malloc(size);
+    if (!g_filedata) {
+        printf("Could not allocate %d bytes\n", size);
+        return -1;
+    }
+    size = g_filesize = fread(g_filedata, 1, size, infile);
+    fclose(infile);
+    return size;
+}
+
+int
+loadBytes(char *buffer, int size)
+{
+    int r = 0;
+    if (!g_filedata) {
+        printf("No file data present\n");
+        return 0;
+    }
+    while (size > 0 && g_fileptr < g_filesize) {
+        *buffer++ = g_filedata[g_fileptr++];
+        --size;
+        ++r;
+    }
+    return r;
+}
+
+int loadfilesingle(char *fname)
+{
+    int num, size, i;
+    int patch = patch_mode;
+    int totnum = 0;
+    int checksum = 0;
+
+    size = loadBinaryFile(fname);
+    if (size < 0) {
+        return 1;
+    }
     if (verbose) printf("Loading %s - %d bytes\n", fname, size);
     hwreset();
     msleep(50);
     tx((uint8_t *)"> Prop_Hex 0 0 0 0", 18);
 
-    while ((num=fread(binbuffer, 1, 128, infile)))
+    while ((num=loadBytes(binbuffer, 128)))
     {
         if (patch)
         {
@@ -200,7 +330,6 @@ int loadfilesingle(char *fname)
 
 int loadfile(char *fname, int address)
 {
-    FILE *infile;
     int num, size;
     int totnum = 0;
     int patch = patch_mode;
@@ -208,15 +337,12 @@ int loadfile(char *fname, int address)
     if (load_mode == LOAD_SINGLE)
         return loadfilesingle(fname);
 
-    infile = fopen(fname, "rb");
-    if (!infile)
+    size = loadBinaryFile(fname);
+    if (size < 0)
     {
         printf("Could not open %s\n", fname);
         return 1;
     }
-    fseek(infile, 0, SEEK_END);
-    size = ftell(infile);
-    fseek(infile, 0, SEEK_SET);
     if (verbose) printf("Loading %s - %d bytes\n", fname, size);
     hwreset();
     msleep(50);
@@ -232,7 +358,7 @@ int loadfile(char *fname, int address)
     txval(address);
     tx((uint8_t *)"~", 1);
     msleep(100);
-    while ((num=fread(buffer, 1, 1024, infile)))
+    while ((num=loadBytes(buffer, 1024)))
     {
         if (patch)
         {


### PR DESCRIPTION
Add ability to load ELF files produced by the GNU linker. This is immediately useful for the riscv-p2 toolchain, and hopefully will be generally useful in the future if we get a full binutils port for P2.
